### PR TITLE
Fixed issue with v-bind to multiple classes

### DIFF
--- a/streaming-thermometer.html
+++ b/streaming-thermometer.html
@@ -8,7 +8,7 @@
 		<script src="config.js"></script>
 	</head>
 	<body>
-		<div id="app" class="py-3 text-light position-relative overflow-hidden rounded" v-bind:class="backgroundColor, thermometerSize">
+		<div id="app" class="py-3 text-light position-relative overflow-hidden rounded" v-bind:class="[backgroundColor, thermometerSize]">
 			<section class="container-fluid">
 				<div class="row align-items-center">
 					<div class="col-3">


### PR DESCRIPTION
Minor Issue: thermometerSize was never being taken into account, due to the incorrect array syntax in the v-bind. Only the first item listed was being respected. I added square brackets per Vue documentation and now the setting of compactView in config.js is honored appropriately.